### PR TITLE
Make the http_accounting_id directive support on the if of the location context

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,18 @@ http{
             http_accounting_id  accounting_id_str;
             ...
         }
+
+        location /api {
+            # for pc
+            http_accounting_id  accounting_id_pc;
+            # for mobile
+            if ($http_user_agent ~* '(Android|webOS|iPhone|iPod|BlackBerry)') {
+                http_accounting_id  accounting_id_mobile;
+            }
+            ...
+        }
     }
+
 }
 ```
 
@@ -60,7 +71,7 @@ http_accounting_id
 
 **default:** *http_accounting_id default*
 
-**content:** *server, location*
+**content:** *server, location, if in location*
 
 Specifies current request belongs to which accounting_id.
 

--- a/src/ngx_http_accounting_module.c
+++ b/src/ngx_http_accounting_module.c
@@ -31,7 +31,8 @@ static ngx_command_t  ngx_http_accounting_commands[] = {
       NULL},
 
     { ngx_string("http_accounting_id"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                        |NGX_CONF_TAKE1,
       ngx_http_accounting_set_accounting_id,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,


### PR DESCRIPTION
Hi @Lax : 
I did the following there points Pls review the code, and thx.
make the `http_accounting_id` directive support on the location of the if context.
may be it's useful for this：
```
    location / {
            # for pc
            http_accounting_id  accounting_id_pc;
            # for mobile
            if ($http_user_agent ~* '(Android|webOS|iPhone|iPod|BlackBerry)') {
                http_accounting_id  accounting_id_mobile;
            }
            ...
    }
```