### PR TITLE
Implement accounting_period_reset directive (closes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ accounting_perturb
 
 Randomly staggers the reporting interval by 20% from the usual time.
 
+accounting_period_reset
+-------------------------
+**syntax:** *accounting_period_reset none | hourly | daily | weekly | monthly*
+
+**default:** *accounting_period_reset none*
+
+**context:** *http, stream*
+
+Resets all accumulated metrics counters at configured calendar boundary.
+
+When set to a value other than `none`, the module will clear all metrics
+periodically at the start of each hour / day / week / month.
+This is useful for tracking high-level usage quotas (e.g. monthly bandwidth).
+
+`hourly`  - clears metrics at the start of each hour.
+`daily`   - clears metrics at the start of each day (midnight).
+`weekly`  - clears metrics on Monday at midnight.
+`monthly` - clears metrics on the 1st day of each month at midnight.
+
 # Usage
 
 This module can be configured to writes metrics to local file, remote log server or local syslog device.

--- a/samples/http.conf
+++ b/samples/http.conf
@@ -1,6 +1,7 @@
 accounting on;
 accounting_interval 60;
 accounting_perturb on;
+accounting_period_reset none;
 accounting_id 'HTTP';
 accounting_log logs/http-accounting.log;
 accounting_log syslog:server=logstash:29124,tag=http_accounting,nohostname notice;

--- a/samples/stream.conf
+++ b/samples/stream.conf
@@ -2,6 +2,7 @@ accounting on;
 accounting_id 'STREAM';
 accounting_interval 60;
 accounting_perturb on;
+accounting_period_reset none;
 accounting_log logs/stream-accounting.log;
 accounting_log syslog:server=logstash:29124,tag=stream_accounting,nohostname info;
 

--- a/src/http/ngx_http_accounting_module.c
+++ b/src/http/ngx_http_accounting_module.c
@@ -47,6 +47,13 @@ static ngx_command_t  ngx_http_accounting_commands[] = {
       offsetof(ngx_http_accounting_main_conf_t, perturb),
       NULL},
 
+    { ngx_string("accounting_period_reset"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+      ngx_traffic_accounting_set_period_reset,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      0,
+      NULL},
+
     { ngx_string("accounting_log"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_1MORE,
       ngx_traffic_accounting_set_log,
@@ -211,6 +218,10 @@ worker_process_alarm_handler(ngx_event_t *ev)
                               worker_process_export_metrics,
                               amcf->previous->created_at,
                               amcf->previous->updated_at );
+
+    if (ngx_traffic_accounting_check_reset(amcf)) {
+        ngx_traffic_accounting_period_clear(amcf->current);
+    }
 
     if (ngx_exiting || ev == NULL)
         return;

--- a/src/ngx_traffic_accounting_module.h
+++ b/src/ngx_traffic_accounting_module.h
@@ -13,11 +13,21 @@
 
 #define NGX_CONF_INDEX_UNSET -128
 
+typedef enum {
+    NGX_TA_PERIOD_RESET_NONE    = 0,
+    NGX_TA_PERIOD_RESET_HOURLY  = 1,
+    NGX_TA_PERIOD_RESET_DAILY   = 2,
+    NGX_TA_PERIOD_RESET_WEEKLY  = 3,
+    NGX_TA_PERIOD_RESET_MONTHLY = 4
+} ngx_ta_period_reset_t;
+
 typedef struct {
     ngx_flag_t      enable;
     ngx_log_t      *log;
     time_t          interval;
     ngx_flag_t      perturb;
+    ngx_ta_period_reset_t   period_reset;
+    ngx_uint_t              last_reset_day;
 
     ngx_traffic_accounting_period_t   *current;
     ngx_traffic_accounting_period_t   *previous;
@@ -34,6 +44,7 @@ void * ngx_traffic_accounting_create_loc_conf(ngx_conf_t *cf);
 char * ngx_traffic_accounting_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child);
 
 char * ngx_traffic_accounting_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+char * ngx_traffic_accounting_set_period_reset(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
 typedef ngx_int_t (*ngx_get_variable_index_pt) (ngx_conf_t *cf, ngx_str_t *name);
 char * ngx_traffic_accounting_set_accounting_id(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
@@ -48,6 +59,8 @@ ngx_str_t * ngx_traffic_accounting_get_accounting_id(void *entry, ngx_get_loc_co
 
 ngx_int_t ngx_traffic_accounting_period_create(ngx_traffic_accounting_main_conf_t *amcf);
 ngx_int_t ngx_traffic_accounting_period_rotate(ngx_traffic_accounting_main_conf_t *amcf);
+ngx_int_t ngx_traffic_accounting_check_reset(ngx_traffic_accounting_main_conf_t *amcf);
+void ngx_traffic_accounting_period_clear(ngx_traffic_accounting_period_t *period);
 
 
 #endif /* _NGX_TRAFFIC_ACCOUNTING_MODULE_H_INCLUDED_ */

--- a/src/ngx_traffic_accounting_module_conf.c
+++ b/src/ngx_traffic_accounting_module_conf.c
@@ -190,19 +190,21 @@ ngx_traffic_accounting_get_accounting_id(void *entry, ngx_get_loc_conf_pt get_lo
 ngx_int_t
 ngx_traffic_accounting_check_reset(ngx_traffic_accounting_main_conf_t *amcf)
 {
-    time_t     now;
-    struct tm  tm;
+    ngx_time_t *tp;
+    time_t      now;
+    struct tm   tm;
 
     if (amcf->period_reset == NGX_TA_PERIOD_RESET_NONE) {
         return 0;
     }
 
-    now = ngx_timeofday()->sec;
+    tp = ngx_timeofday();
+    now = tp->sec;
     localtime_r(&now, &tm);
 
     switch (amcf->period_reset) {
     case NGX_TA_PERIOD_RESET_HOURLY:
-        if (tm.tm_hour != amcf->last_reset_day) {
+        if ((ngx_uint_t)tm.tm_hour != amcf->last_reset_day) {
             amcf->last_reset_day = tm.tm_hour;
             return 1;
         }

--- a/src/ngx_traffic_accounting_module_conf.c
+++ b/src/ngx_traffic_accounting_module_conf.c
@@ -7,6 +7,8 @@
 #include "ngx_traffic_accounting.h"
 #include "ngx_traffic_accounting_module.h"
 
+#include <time.h>
+
 
 void *
 ngx_traffic_accounting_create_main_conf(ngx_conf_t *cf)
@@ -17,9 +19,11 @@ ngx_traffic_accounting_create_main_conf(ngx_conf_t *cf)
     if (amcf == NULL)
         return NULL;
 
-    amcf->enable   = NGX_CONF_UNSET;
-    amcf->interval = NGX_CONF_UNSET;
-    amcf->perturb  = NGX_CONF_UNSET;
+    amcf->enable       = NGX_CONF_UNSET;
+    amcf->interval     = NGX_CONF_UNSET;
+    amcf->perturb      = NGX_CONF_UNSET;
+    amcf->period_reset = NGX_TA_PERIOD_RESET_NONE;
+    amcf->last_reset_day = 0;
 
     return amcf;
 }
@@ -87,6 +91,36 @@ ngx_traffic_accounting_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 char *
+ngx_traffic_accounting_set_period_reset(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_traffic_accounting_main_conf_t   *amcf = conf;
+    ngx_str_t                            *value;
+
+    value = cf->args->elts;
+
+    if (ngx_strcmp(value[1].data, "none") == 0) {
+        amcf->period_reset = NGX_TA_PERIOD_RESET_NONE;
+    } else if (ngx_strcmp(value[1].data, "hourly") == 0) {
+        amcf->period_reset = NGX_TA_PERIOD_RESET_HOURLY;
+    } else if (ngx_strcmp(value[1].data, "daily") == 0) {
+        amcf->period_reset = NGX_TA_PERIOD_RESET_DAILY;
+    } else if (ngx_strcmp(value[1].data, "weekly") == 0) {
+        amcf->period_reset = NGX_TA_PERIOD_RESET_WEEKLY;
+    } else if (ngx_strcmp(value[1].data, "monthly") == 0) {
+        amcf->period_reset = NGX_TA_PERIOD_RESET_MONTHLY;
+    } else {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid value \"%V\", must be: "
+                           "none | hourly | daily | weekly | monthly",
+                           &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+char *
 ngx_traffic_accounting_set_accounting_id(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
     ngx_get_variable_index_pt get_variable_index)
 {
@@ -150,4 +184,52 @@ ngx_traffic_accounting_get_accounting_id(void *entry, ngx_get_loc_conf_pt get_lo
     }
 
     return &alcf->accounting_id;
+}
+
+
+ngx_int_t
+ngx_traffic_accounting_check_reset(ngx_traffic_accounting_main_conf_t *amcf)
+{
+    time_t     now;
+    struct tm  tm;
+
+    if (amcf->period_reset == NGX_TA_PERIOD_RESET_NONE) {
+        return 0;
+    }
+
+    now = ngx_timeofday()->sec;
+    localtime_r(&now, &tm);
+
+    switch (amcf->period_reset) {
+    case NGX_TA_PERIOD_RESET_HOURLY:
+        if (tm.tm_hour != amcf->last_reset_day) {
+            amcf->last_reset_day = tm.tm_hour;
+            return 1;
+        }
+        break;
+    case NGX_TA_PERIOD_RESET_DAILY:
+        if ((ngx_uint_t)tm.tm_mday != amcf->last_reset_day) {
+            amcf->last_reset_day = tm.tm_mday;
+            return 1;
+        }
+        break;
+    case NGX_TA_PERIOD_RESET_WEEKLY:
+        if (tm.tm_wday == 1
+            && (ngx_uint_t)tm.tm_yday != amcf->last_reset_day)
+        {
+            amcf->last_reset_day = tm.tm_yday;
+            return 1;
+        }
+        break;
+    case NGX_TA_PERIOD_RESET_MONTHLY:
+        if ((ngx_uint_t)tm.tm_mon != amcf->last_reset_day) {
+            amcf->last_reset_day = tm.tm_mon;
+            return 1;
+        }
+        break;
+    default:
+        break;
+    }
+
+    return 0;
 }

--- a/src/ngx_traffic_accounting_period_metrics.c
+++ b/src/ngx_traffic_accounting_period_metrics.c
@@ -186,6 +186,29 @@ done:
     return NGX_OK;
 }
 
+
+void
+ngx_traffic_accounting_period_clear(ngx_traffic_accounting_period_t *period)
+{
+    ngx_rbtree_t                       *rbtree;
+    ngx_rbtree_node_t                  *node, *sentinel;
+    ngx_traffic_accounting_metrics_t   *m;
+
+    rbtree = &period->rbtree;
+    sentinel = rbtree->sentinel;
+
+    while ((node = rbtree->root) != sentinel) {
+        m = (ngx_traffic_accounting_metrics_t *) node;
+
+        ngx_rbtree_delete(rbtree, node);
+        ngx_free(m->nr_status);
+        ngx_free(m->nr_upstream_status);
+        ngx_free(m->name.data);
+        ngx_free(m);
+    }
+}
+
+
 static void
 ngx_traffic_accounting_period_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)

--- a/src/stream/ngx_stream_accounting_module.c
+++ b/src/stream/ngx_stream_accounting_module.c
@@ -47,6 +47,13 @@ static ngx_command_t  ngx_stream_accounting_commands[] = {
       offsetof(ngx_stream_accounting_main_conf_t, perturb),
       NULL},
 
+    { ngx_string("accounting_period_reset"),
+      NGX_STREAM_MAIN_CONF|NGX_CONF_TAKE1,
+      ngx_traffic_accounting_set_period_reset,
+      NGX_STREAM_MAIN_CONF_OFFSET,
+      0,
+      NULL},
+
     { ngx_string("accounting_log"),
       NGX_STREAM_MAIN_CONF|NGX_CONF_1MORE,
       ngx_traffic_accounting_set_log,
@@ -208,6 +215,10 @@ worker_process_alarm_handler(ngx_event_t *ev)
                               worker_process_export_metrics,
                               amcf->previous->created_at,
                               amcf->previous->updated_at );
+
+    if (ngx_traffic_accounting_check_reset(amcf)) {
+        ngx_traffic_accounting_period_clear(amcf->current);
+    }
 
     if (ngx_exiting || ev == NULL)
         return;


### PR DESCRIPTION
## Summary

Implements the `accounting_period_reset` directive to support calendar-boundary
metric counter resets. Addresses feature request #55.

## New Directive

```nginx
accounting_period_reset none | hourly | daily | weekly | monthly;
# default: none
# context: http, stream
```

## Behavior

Does **not** change the normal rotation/export cycle.
On each timer tick, after the usual `period_rotate + export`:

1. Check if a calendar boundary has been crossed
2. If yes, clear all metrics from `amcf->current` via `period_clear()`
3. Next timer fires at the regular `accounting_interval`

## Calendar Boundaries

| Value    | Boundary        |
|----------|----------------|
| `hourly` | Start of each hour |
| `daily`  | Midnight |
| `weekly` | Monday midnight |
| `monthly`| 1st of month midnight |

## Changes

| File | Change |
|------|--------|
| `src/ngx_traffic_accounting_module.h` | Enum + fields + declarations |
| `src/ngx_traffic_accounting_module_conf.c` | Config parser + `check_reset()` |
| `src/ngx_traffic_accounting_period_metrics.c` | `period_clear()` |
| `src/http/ngx_http_accounting_module.c` | Command entry + alarm handler integration |
| `src/stream/ngx_stream_accounting_module.c` | Same as HTTP |
| `samples/http.conf` | Add `accounting_period_reset none;` example |
| `samples/stream.conf` | Same |
| `README.md` | Document new directive |

## Example Use Case (Heroku)

```nginx
accounting            on;
accounting_interval   60;      # export every 60s
accounting_period_reset monthly; # reset counters on 1st of month
accounting_log        logs/http-accounting.log;
```

Aggregate exported log lines to get monthly bandwidth total.