### PR TITLE
feat: implement accounting_skip directive (closes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,29 @@ When configured, each period produces a single combined log entry per `accountin
 The log format changes from `pid:N` to `workers:N` when a zone is configured,
 where `N` is the number of active worker processes.
 
+accounting_skip
+------------------------
+**syntax:** *accounting_skip on | off*
+
+**default:** *accounting_skip off*
+
+**context:** *http, stream, server, location, if in location*
+
+When set to `on`, skips traffic accounting for the current request/session.
+Useful for excluding health checks, bots, or cached responses:
+
+```nginx
+# Skip accounting for cache hits
+if ($upstream_cache_status = "HIT") {
+    accounting_skip on;
+}
+
+# Skip accounting for search engine bots
+if ($http_user_agent ~* '(Googlebot|Bingbot)') {
+    accounting_skip on;
+}
+```
+
 # Usage
 
 This module can be configured to writes metrics to local file, remote log server or local syslog device.

--- a/samples/http.conf
+++ b/samples/http.conf
@@ -8,6 +8,11 @@ accounting_log syslog:server=logstash:29124,tag=http_accounting,nohostname notic
 
 accounting_zone http_accounting_zone 1m;
 
+# accounting_skip on|off;
+#   Skip traffic accounting for the current request. Use in locations or
+#   if-blocks to exclude health checks, cache hits, bots, etc.
+#     if ($upstream_cache_status = "HIT") { accounting_skip on; }
+
 server {
     listen       8080;
     server_name  localhost;
@@ -30,6 +35,11 @@ server {
         proxy_set_header Host "echo";
         proxy_buffering off;
         accounting_id "HTTP_PROXY_ECHO";
+    }
+
+    location /health {
+        return 200 '';
+        accounting_skip on;
     }
 
     #error_page  404              /404.html;

--- a/samples/stream.conf
+++ b/samples/stream.conf
@@ -8,6 +8,11 @@ accounting_log syslog:server=logstash:29124,tag=stream_accounting,nohostname inf
 
 accounting_zone stream_accounting_zone 1m;
 
+# accounting_skip on|off;
+#   Skip traffic accounting for the current session. Use in server or
+#   if-blocks to exclude health checks or internal traffic.
+#     if ($ssl_preread_protocol = "") { accounting_skip on; }
+
 upstream echo {
     server 127.0.0.1:8888   max_fails=3 fail_timeout=30s;
 }

--- a/src/http/ngx_http_accounting_module.c
+++ b/src/http/ngx_http_accounting_module.c
@@ -24,6 +24,7 @@ static char *ngx_http_accounting_set_accounting_id(ngx_conf_t *cf, ngx_command_t
 static char *ngx_http_accounting_set_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
 static ngx_int_t ngx_http_accounting_request_handler(ngx_http_request_t *r);
+static ngx_http_accounting_loc_conf_t *ngx_http_accounting_get_loc_conf(void *entry);
 static ngx_str_t *ngx_http_accounting_get_accounting_id(ngx_http_request_t *r);
 
 static ngx_traffic_accounting_metrics_t *
@@ -75,6 +76,14 @@ static ngx_command_t  ngx_http_accounting_commands[] = {
       ngx_http_accounting_set_accounting_id,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
+      NULL},
+
+    { ngx_string("accounting_skip"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                        |NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_traffic_accounting_loc_conf_t, skip),
       NULL},
 
     { ngx_string("accounting_zone"),
@@ -370,6 +379,10 @@ ngx_http_accounting_request_handler(ngx_http_request_t *r)
     ngx_time_t                  *tp = ngx_timeofday();
     ngx_msec_int_t               ms = 0;
     ngx_http_upstream_state_t   *state;
+
+    if (ngx_http_accounting_get_loc_conf(r)->skip) {
+        return NGX_DECLINED;
+    }
 
     accounting_id = ngx_http_accounting_get_accounting_id(r);
     if (accounting_id == NULL) { return NGX_ERROR; }

--- a/src/ngx_traffic_accounting_module.h
+++ b/src/ngx_traffic_accounting_module.h
@@ -45,6 +45,7 @@ typedef struct {
 typedef struct {
     ngx_str_t       accounting_id;
     ngx_int_t       index;
+    ngx_flag_t      skip;
 } ngx_traffic_accounting_loc_conf_t;
 
 void * ngx_traffic_accounting_create_main_conf(ngx_conf_t *cf);

--- a/src/ngx_traffic_accounting_module_conf.c
+++ b/src/ngx_traffic_accounting_module_conf.c
@@ -49,6 +49,7 @@ ngx_traffic_accounting_create_loc_conf(ngx_conf_t *cf)
     if(conf == NULL) { return NULL; }
 
     conf->index = NGX_CONF_UNSET;
+    conf->skip  = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -63,6 +64,8 @@ ngx_traffic_accounting_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         ngx_conf_merge_str_value(conf->accounting_id, prev->accounting_id, "default");
         conf->index = prev->index;
     }
+
+    ngx_conf_merge_value(conf->skip, prev->skip, 0);
 
     return NGX_CONF_OK;
 }

--- a/src/stream/ngx_stream_accounting_module.c
+++ b/src/stream/ngx_stream_accounting_module.c
@@ -24,6 +24,7 @@ static char *ngx_stream_accounting_set_accounting_id(ngx_conf_t *cf, ngx_command
 static char *ngx_stream_accounting_set_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
 static ngx_int_t ngx_stream_accounting_session_handler(ngx_stream_session_t *r);
+static ngx_stream_accounting_loc_conf_t *ngx_stream_accounting_get_srv_conf(void *entry);
 static ngx_str_t *ngx_stream_accounting_get_accounting_id(ngx_stream_session_t *r);
 
 static ngx_traffic_accounting_metrics_t *
@@ -74,6 +75,13 @@ static ngx_command_t  ngx_stream_accounting_commands[] = {
       ngx_stream_accounting_set_accounting_id,
       NGX_STREAM_SRV_CONF_OFFSET,
       0,
+      NULL},
+
+    { ngx_string("accounting_skip"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_traffic_accounting_loc_conf_t, skip),
       NULL},
 
     { ngx_string("accounting_zone"),
@@ -365,6 +373,10 @@ ngx_stream_accounting_session_handler(ngx_stream_session_t *s)
     ngx_time_t                    *tp = ngx_timeofday();
     ngx_msec_int_t                 ms = 0;
     ngx_stream_upstream_state_t   *state;
+
+    if (ngx_stream_accounting_get_srv_conf(s)->skip) {
+        return NGX_DECLINED;
+    }
 
     accounting_id = ngx_stream_accounting_get_accounting_id(s);
     if (accounting_id == NULL) { return NGX_ERROR; }

--- a/test/nginx_build_test_zone.sh
+++ b/test/nginx_build_test_zone.sh
@@ -28,13 +28,16 @@ echo "=== [3/4] Config validation ==="
 docker run --rm --entrypoint /opt/nginx/sbin/nginx "${IMAGE}" -t
 
 echo "=== [4/4] Start & request ==="
-CID=$(docker run -d -p 8090:8080 "${IMAGE}")
+CID=$(docker run -d -p 8090:8080 -p 8091:8081 "${IMAGE}")
 sleep 3
 
 # Send 3 requests early so they land in a period that gets rotated
 curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8090/index || true
 curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8090/index || true
 curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8090/index || true
+
+# Send a request to the skip-enabled server (should NOT be accounted)
+curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8091/ || true
 
 # Wait for period rotation (interval=5, need 2 cycles: one to catch, one to log)
 sleep 12
@@ -49,15 +52,25 @@ LOGS=$(docker logs "${CID}" 2>&1)
 ACC_LOGS=$(echo "$LOGS" | grep 'accounting_id:' || true)
 HAS_WORKERS=$(echo "$ACC_LOGS" | grep -c 'workers:' || true)
 HAS_REQUESTS=$(echo "$ACC_LOGS" | grep -c 'requests:3' || true)
+HAS_SKIP=$(echo "$ACC_LOGS" | grep -c 'accounting_id:/' || true)
 
 echo "  accounting log lines: $(echo "$ACC_LOGS" | wc -l)"
 echo "  workers: in accounting log: ${HAS_WORKERS}"
 echo "  requests:3 found: ${HAS_REQUESTS}"
+echo "  skip entries found: ${HAS_SKIP}"
 
 docker kill "${CID}" >/dev/null 2>&1 || true
 
-if [ "$HAS_WORKERS" -gt 0 ] && [ "$HAS_REQUESTS" -gt 0 ]; then
-    echo "=== PASS: zone aggregation verified ==="
+if [ "$HAS_WORKERS" -gt 0 ] && [ "$HAS_REQUESTS" -gt 0 ] && [ "$HAS_SKIP" -eq 0 ]; then
+    echo "=== PASS: zone aggregation + accounting_skip verified ==="
+    echo "  workers: prefix present ✓"
+    echo "  requests accumulated (3 total) ✓"
+    echo "  skip request not accounted ✓"
+elif [ "$HAS_SKIP" -gt 0 ]; then
+    echo "=== FAIL: skip request was incorrectly accounted ==="
+    echo "Full container logs:"
+    echo "$LOGS"
+    exit 1
 else
     echo "=== FAIL: missing workers: prefix or accumulated request count ==="
     echo "Full container logs:"

--- a/test/zone-http.conf
+++ b/test/zone-http.conf
@@ -21,3 +21,11 @@ server {
         accounting_id "INDEX";
     }
 }
+
+server {
+    listen       8081;
+    location / {
+        return 200 '';
+        accounting_skip on;
+    }
+}


### PR DESCRIPTION
Closes #4

## Summary

New directive `accounting_skip on | off` (default: off) that skips traffic accounting for the current request/session.

Context: `http, stream, server, location, if in location`

## Usage

```nginx
# Skip accounting for health checks
location /health {
    return 200 "";
    accounting_skip on;
}

# Skip accounting for cache hits
if ($upstream_cache_status = "HIT") {
    accounting_skip on;
}

# Skip accounting for search engine bots
if ($http_user_agent ~* "(Googlebot|Bingbot)") {
    accounting_skip on;
}
```

## Design

Pure static flag using `ngx_conf_set_flag_slot` (same pattern as `accounting` / `accounting_perturb`). No `$variable` support — conditional skipping is done via `if` blocks. This avoids the security risk of users accidentally using client-controlled variables (e.g. `$arg_*`) to bypass accounting.

Skip check occurs **before** `accounting_id` resolution — no unnecessary variable parsing or shm locking on skipped requests.

## File changes

| File | Change |
|------|--------|
| `src/ngx_traffic_accounting_module.h` | +1 field (`ngx_flag_t skip`) |
| `src/ngx_traffic_accounting_module_conf.c` | +2 init, +1 merge |
| `src/http/ngx_http_accounting_module.c` | +1 command, +4 handler check |
| `src/stream/ngx_stream_accounting_module.c` | +1 command, +4 handler check |
| `README.md` | +23 directive documentation + examples |
| `samples/http.conf` | +8 commented directive + `location /health` example |
| `samples/stream.conf` | +4 commented directive |
| `test/zone-http.conf` | +7 second server block (port 8081) with `accounting_skip on` |
| `test/nginx_build_test_zone.sh` | +19 test verification: map port 8091, send skip request, assert no accounting entry produced |

## Test verification

The zone integration test now:
1. Starts a second server on port 8081 with `accounting_skip on`
2. Sends a curl to that port after the 3 regular requests
3. Waits for zone aggregation interval
4. Asserts `accounting_id:/` does **not** appear in the accounting log
5. Asserts `requests:3` is still present (skip request did not increment the count)