### PR TITLE
fix: NULL safety guards (H1/H2/H3) + closelog

### DIFF
--- a/src/http/ngx_http_accounting_module.c
+++ b/src/http/ngx_http_accounting_module.c
@@ -174,6 +174,9 @@ ngx_http_accounting_process_init(ngx_cycle_t *cycle)
 
     if (amcf->shm_zone != NULL) {
         amcf->shm_head = amcf->shm_zone->data;
+        if (amcf->shm_head == NULL) {
+            return NGX_ERROR;
+        }
         amcf->fetch_metrics = ngx_http_shm_fetch_metrics;
 
         ngx_traffic_accounting_shm_worker_join(amcf->shm_head);
@@ -227,6 +230,7 @@ ngx_http_accounting_process_exit(ngx_cycle_t *cycle)
                       "pid:%i|stop http traffic accounting", ngx_getpid());
     } else {
         syslog(LOG_INFO, "pid:%i|stop http traffic accounting", ngx_getpid());
+        closelog();
     }
 }
 
@@ -428,8 +432,11 @@ ngx_http_accounting_request_handler(ngx_http_request_t *r)
     ngx_msec_int_t               ms = 0;
     ngx_http_upstream_state_t   *state;
 
-    if (ngx_http_accounting_get_loc_conf(r)->skip) {
-        return NGX_DECLINED;
+    {
+        ngx_http_accounting_loc_conf_t *alcf = ngx_http_accounting_get_loc_conf(r);
+        if (alcf == NULL || alcf->skip) {
+            return NGX_DECLINED;
+        }
     }
 
     accounting_id = ngx_http_accounting_get_accounting_id(r);
@@ -452,7 +459,9 @@ ngx_http_accounting_request_handler(ngx_http_request_t *r)
 
     metrics->nr_entries += 1;
     metrics->bytes_in += r->request_length;
-    metrics->bytes_out += r->connection->sent;
+    if (r->connection) {
+        metrics->bytes_out += r->connection->sent;
+    }
 
     if (r->err_status) {
         status = r->err_status;
@@ -515,8 +524,12 @@ ngx_http_shm_fetch_metrics(void *context, ngx_str_t *name)
     ngx_traffic_accounting_main_conf_t *amcf = context;
     ngx_traffic_accounting_metrics_t   *metrics;
 
+    if (amcf->shm_head == NULL || amcf->shm_head->current == NULL) {
+        return NULL;
+    }
+
     metrics = ngx_traffic_accounting_shm_fetch_metrics(amcf->shm_head->current,
-                                                        name, amcf->log);
+                                                         name, amcf->log);
     if (metrics != NULL) {
         amcf->shm_head->current->updated_at_sec = ngx_time();
     }

--- a/src/stream/ngx_stream_accounting_module.c
+++ b/src/stream/ngx_stream_accounting_module.c
@@ -170,6 +170,9 @@ ngx_stream_accounting_process_init(ngx_cycle_t *cycle)
 
     if (amcf->shm_zone != NULL) {
         amcf->shm_head = amcf->shm_zone->data;
+        if (amcf->shm_head == NULL) {
+            return NGX_ERROR;
+        }
         amcf->fetch_metrics = ngx_stream_shm_fetch_metrics;
 
         ngx_traffic_accounting_shm_worker_join(amcf->shm_head);
@@ -223,6 +226,7 @@ ngx_stream_accounting_process_exit(ngx_cycle_t *cycle)
                       "pid:%i|stop stream traffic accounting", ngx_getpid());
     } else {
         syslog(LOG_INFO, "pid:%i|stop stream traffic accounting", ngx_getpid());
+        closelog();
     }
 }
 
@@ -422,8 +426,11 @@ ngx_stream_accounting_session_handler(ngx_stream_session_t *s)
     ngx_msec_int_t                 ms = 0;
     ngx_stream_upstream_state_t   *state;
 
-    if (ngx_stream_accounting_get_srv_conf(s)->skip) {
-        return NGX_DECLINED;
+    {
+        ngx_stream_accounting_loc_conf_t *alcf = ngx_stream_accounting_get_srv_conf(s);
+        if (alcf == NULL || alcf->skip) {
+            return NGX_DECLINED;
+        }
     }
 
     accounting_id = ngx_stream_accounting_get_accounting_id(s);
@@ -446,7 +453,9 @@ ngx_stream_accounting_session_handler(ngx_stream_session_t *s)
 
     metrics->nr_entries += 1;
     metrics->bytes_in += s->received;
-    metrics->bytes_out += s->connection->sent;
+    if (s->connection) {
+        metrics->bytes_out += s->connection->sent;
+    }
 
     if (s->status) {
         status = s->status;
@@ -502,8 +511,12 @@ ngx_stream_shm_fetch_metrics(void *context, ngx_str_t *name)
     ngx_traffic_accounting_main_conf_t *amcf = context;
     ngx_traffic_accounting_metrics_t   *metrics;
 
+    if (amcf->shm_head == NULL || amcf->shm_head->current == NULL) {
+        return NULL;
+    }
+
     metrics = ngx_traffic_accounting_shm_fetch_metrics(amcf->shm_head->current,
-                                                        name, amcf->log);
+                                                         name, amcf->log);
     if (metrics != NULL) {
         amcf->shm_head->current->updated_at_sec = ngx_time();
     }


### PR DESCRIPTION
## Changes

NULL safety hardening across HTTP and stream modules.

| ID | Fix | Files |
|----|-----|-------|
| H1 | SHM fetch: guard `shm_head` / `current` against NULL | `http.c`, `stream.c` |
| H1 | `process_init`: reject NULL `shm_zone->data` | `http.c`, `stream.c` |
| H2 | Guard `r->connection` / `s->connection` deref | `http.c`, `stream.c` |
| H3 | Guard `get_loc_conf` / `get_srv_conf` in skip check | `http.c`, `stream.c` |
| M1 | `closelog()` to pair with `openlog()` | `http.c`, `stream.c` |

## Testing

- ✓ Compile (nginx 1.30.1 with --with-stream)
- ✓ Config test passes
- ✓ Runtime: request + accounting log produced