### PR TITLE
Release v2.0.1: add Docker build and GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build modules
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.build
+          outputs: type=local,dest=modules
+          target: modules
+
+      - name: Create combined module
+        run: cp modules/ngx_http_accounting_module.so modules/ngx_http_accounting_module-with-stream.so
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            modules/ngx_http_accounting_module.so
+            modules/ngx_stream_accounting_module.so
+            modules/ngx_http_accounting_module-with-stream.so
+          body: |
+            ## v2.0.1
+
+            Pre-built nginx module binaries built with Docker and GitHub Actions.

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,6 @@
 ARG NGX_VER=1.26.2
 
-FROM alpine:3.20 AS builder
+FROM alpine:3.20 AS base
 ARG NGX_VER
 
 RUN apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar
@@ -12,13 +12,29 @@ RUN curl -sL http://nginx.org/download/nginx-${NGX_VER}.tar.gz | tar xz
 WORKDIR /src/nginx-${NGX_VER}
 COPY . traffic-accounting-nginx-module
 
+FROM base AS both
+ARG NGX_VER
 RUN ./configure --prefix=/opt/nginx \
-    --with-stream \
+    --with-stream --with-compat \
+    --add-dynamic-module=traffic-accounting-nginx-module \
+    && make modules
+
+FROM base AS http-only
+ARG NGX_VER
+RUN ./configure --prefix=/opt/nginx \
     --with-compat \
+    --add-dynamic-module=traffic-accounting-nginx-module \
+    && make modules
+
+FROM base AS stream-only
+ARG NGX_VER
+RUN ./configure --prefix=/opt/nginx \
+    --without-http --with-stream --with-compat \
     --add-dynamic-module=traffic-accounting-nginx-module \
     && make modules
 
 FROM scratch AS modules
 ARG NGX_VER
-COPY --from=builder /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /
-COPY --from=builder /src/nginx-${NGX_VER}/objs/ngx_stream_accounting_module.so /
+COPY --from=both /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /ngx_http_accounting_module-with-stream.so
+COPY --from=http-only /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /ngx_http_accounting_module.so
+COPY --from=stream-only /src/nginx-${NGX_VER}/objs/ngx_stream_accounting_module.so /ngx_stream_accounting_module.so

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,16 +1,14 @@
-FROM alpine:3.18 AS builder
+FROM alpine:3.20 AS builder
 
-RUN apk add --no-cache gcc make pcre-dev zlib-dev openssl-dev linux-headers curl tar
+RUN apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar
 
-ENV NGX_VER 1.26.2
-ENV WORKDIR /src
-ENV NGX_SRC_DIR ${WORKDIR}/nginx-${NGX_VER}
+ENV NGX_VER=1.26.2
 
-WORKDIR ${WORKDIR}
+WORKDIR /src
 
 RUN curl -sL http://nginx.org/download/nginx-${NGX_VER}.tar.gz | tar xz
 
-WORKDIR ${NGX_SRC_DIR}
+WORKDIR /src/nginx-${NGX_VER}
 COPY . traffic-accounting-nginx-module
 
 RUN ./configure --prefix=/opt/nginx \
@@ -20,5 +18,5 @@ RUN ./configure --prefix=/opt/nginx \
     && make modules
 
 FROM scratch AS modules
-COPY --from=builder ${NGX_SRC_DIR}/objs/ngx_http_accounting_module.so /
-COPY --from=builder ${NGX_SRC_DIR}/objs/ngx_stream_accounting_module.so /
+COPY --from=builder /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /
+COPY --from=builder /src/nginx-${NGX_VER}/objs/ngx_stream_accounting_module.so /

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,24 @@
+FROM alpine:3.18 AS builder
+
+RUN apk add --no-cache gcc make pcre-dev zlib-dev openssl-dev linux-headers curl tar
+
+ENV NGX_VER 1.26.2
+ENV WORKDIR /src
+ENV NGX_SRC_DIR ${WORKDIR}/nginx-${NGX_VER}
+
+WORKDIR ${WORKDIR}
+
+RUN curl -sL http://nginx.org/download/nginx-${NGX_VER}.tar.gz | tar xz
+
+WORKDIR ${NGX_SRC_DIR}
+COPY . traffic-accounting-nginx-module
+
+RUN ./configure --prefix=/opt/nginx \
+    --with-stream \
+    --with-compat \
+    --add-dynamic-module=traffic-accounting-nginx-module \
+    && make modules
+
+FROM scratch AS modules
+COPY --from=builder ${NGX_SRC_DIR}/objs/ngx_http_accounting_module.so /
+COPY --from=builder ${NGX_SRC_DIR}/objs/ngx_stream_accounting_module.so /

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,8 +1,9 @@
+ARG NGX_VER=1.26.2
+
 FROM alpine:3.20 AS builder
+ARG NGX_VER
 
 RUN apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar
-
-ENV NGX_VER=1.26.2
 
 WORKDIR /src
 
@@ -18,5 +19,6 @@ RUN ./configure --prefix=/opt/nginx \
     && make modules
 
 FROM scratch AS modules
+ARG NGX_VER
 COPY --from=builder /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /
 COPY --from=builder /src/nginx-${NGX_VER}/objs/ngx_stream_accounting_module.so /


### PR DESCRIPTION
### Changes

- Add `Dockerfile.build`: multi-stage build producing  modules (both, http-only, stream-only)
- Add `.github/workflows/build.yml`: auto-build and attach module artifacts on tag push
- Fixes to Dockerfile.build (build-base, ARG scoping, all 3 variants)

### Commits
* 08b4962 fix Dockerfile.build: build all 3 module variants (both/http-only/stream-only)
* 8c92c66 fix Dockerfile.build: use top-level ARG for NGX_VER across stages
* 5af84d5 fix Dockerfile.build: use build-base, fix ENV syntax, hardcode paths
* dfc644e v2.0.1 release: add Docker build and GitHub Actions
* 51199a8 v2.0.1: add Docker build and GitHub Actions release workflow