### PR TITLE
Split config into HTTP/stream modules + test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,4 +39,7 @@ jobs:
           body: |
             ## ${{ github.ref_name }}
 
+            ![Test](https://img.shields.io/github/actions/workflow/status/Lax/traffic-accounting-nginx-module/test.yml?branch=${{ github.ref_name }}&label=Test)
+            ![Build and Release](https://img.shields.io/github/actions/workflow/status/Lax/traffic-accounting-nginx-module/build.yml?branch=${{ github.ref_name }}&label=Build%20and%20Release)
+
             Pre-built nginx module binaries built with Docker and GitHub Actions.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             modules/ngx_http_accounting_module.so
             modules/ngx_stream_accounting_module.so
             modules/ngx_http_accounting_module-with-stream.so
           body: |
-            ## v2.0.1
+            ## ${{ github.ref_name }}
 
             Pre-built nginx module binaries built with Docker and GitHub Actions.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: Test
+on: [push, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build test image
+        run: docker build -f test/Dockerfile.test -t acc-test:rt .
+      - name: Run all tests
+        run: bash test/run.sh --skip-build

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -16,7 +16,7 @@ FROM base AS both
 ARG NGX_VER
 RUN ./configure --prefix=/opt/nginx \
     --with-stream --with-compat \
-    --add-dynamic-module=traffic-accounting-nginx-module \
+    --add-dynamic-module=traffic-accounting-nginx-module --add-dynamic-module=traffic-accounting-nginx-module/stream \
     && make modules
 
 FROM base AS http-only
@@ -30,7 +30,7 @@ FROM base AS stream-only
 ARG NGX_VER
 RUN ./configure --prefix=/opt/nginx \
     --without-http --with-stream --with-compat \
-    --add-dynamic-module=traffic-accounting-nginx-module \
+    --add-dynamic-module=traffic-accounting-nginx-module/stream \
     && make modules
 
 FROM scratch AS modules

--- a/config
+++ b/config
@@ -1,4 +1,4 @@
-ngx_addon_name="traffic-accounting-nginx-module"
+ngx_addon_name="ngx_http_accounting_module"
 
 TRAFFIC_ACCOUNTING_DEPS=" \
     $ngx_addon_dir/src/ngx_traffic_accounting.h \
@@ -20,39 +20,11 @@ HTTP_ACCOUNTING_SRCS=" \
     $ngx_addon_dir/src/http/ngx_http_accounting_statuses.c \
     "
 
-STREAM_ACCOUNTING_DEPS=" \
-    $ngx_addon_dir/src/stream/ngx_stream_accounting_module.h \
-    "
-STREAM_ACCOUNTING_SRCS=" \
-    $ngx_addon_dir/src/stream/ngx_stream_accounting_module.c \
-    $ngx_addon_dir/src/stream/ngx_stream_accounting_statuses.c \
-    "
-
-ngx_module_type=
-ngx_module_name=
+ngx_module_type=HTTP
+ngx_module_name="ngx_http_accounting_module"
 ngx_module_incs=$ngx_addon_dir
-ngx_module_deps=$TRAFFIC_ACCOUNTING_DEPS
-ngx_module_srcs=$TRAFFIC_ACCOUNTING_SRCS
+ngx_module_deps=$TRAFFIC_ACCOUNTING_DEPS$HTTP_ACCOUNTING_DEPS
+ngx_module_srcs=$TRAFFIC_ACCOUNTING_SRCS$HTTP_ACCOUNTING_SRCS
 ngx_module_libs=
-
-if [ $HTTP != NO ]
-then
-    ngx_module_type=HTTP
-    ngx_module_name="ngx_http_accounting_module"
-    ngx_module_deps="$ngx_module_deps $HTTP_ACCOUNTING_DEPS"
-    ngx_module_srcs="$ngx_module_srcs $HTTP_ACCOUNTING_SRCS"
-fi
-
-if [ $STREAM != NO ]
-then
-    ngx_module_type=STREAM
-    if test -n "$ngx_module_name"; then
-      ngx_module_name="ngx_http_accounting_module ngx_stream_accounting_module"
-    else
-      ngx_module_name="ngx_stream_accounting_module"
-    fi
-    ngx_module_deps="$ngx_module_deps $STREAM_ACCOUNTING_DEPS"
-    ngx_module_srcs="$ngx_module_srcs $STREAM_ACCOUNTING_SRCS"
-fi
 
 . auto/module

--- a/stream/config
+++ b/stream/config
@@ -1,0 +1,32 @@
+ngx_addon_name="ngx_stream_accounting_module"
+
+TA_SRC=$ngx_addon_dir/../src
+
+TRAFFIC_ACCOUNTING_DEPS=" \
+    $TA_SRC/ngx_traffic_accounting.h \
+    $TA_SRC/ngx_traffic_accounting_module.h \
+    "
+TRAFFIC_ACCOUNTING_SRCS=" \
+    $TA_SRC/ngx_traffic_accounting_log.c \
+    $TA_SRC/ngx_traffic_accounting_module.c \
+    $TA_SRC/ngx_traffic_accounting_module_conf.c \
+    $TA_SRC/ngx_traffic_accounting_period_metrics.c \
+    $TA_SRC/ngx_traffic_accounting_statuses.c \
+    "
+
+STREAM_ACCOUNTING_DEPS=" \
+    $TA_SRC/stream/ngx_stream_accounting_module.h \
+    "
+STREAM_ACCOUNTING_SRCS=" \
+    $TA_SRC/stream/ngx_stream_accounting_module.c \
+    $TA_SRC/stream/ngx_stream_accounting_statuses.c \
+    "
+
+ngx_module_type=STREAM
+ngx_module_name="ngx_stream_accounting_module"
+ngx_module_incs=$TA_SRC
+ngx_module_deps=$TRAFFIC_ACCOUNTING_DEPS$STREAM_ACCOUNTING_DEPS
+ngx_module_srcs=$TRAFFIC_ACCOUNTING_SRCS$STREAM_ACCOUNTING_SRCS
+ngx_module_libs=
+
+. auto/module

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -1,0 +1,22 @@
+ARG NGX_VER=1.26.2
+
+FROM alpine:3.20 AS base
+ARG NGX_VER
+RUN apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar
+WORKDIR /src
+RUN curl -sL http://nginx.org/download/nginx-${NGX_VER}.tar.gz | tar xz
+WORKDIR /src/nginx-${NGX_VER}
+COPY . traffic-accounting-nginx-module
+
+FROM base AS compile
+RUN ./configure --prefix=/opt/nginx --with-stream --with-compat \
+    --add-dynamic-module=traffic-accounting-nginx-module \
+    --add-dynamic-module=traffic-accounting-nginx-module/stream \
+    && make -s -j$(nproc) install \
+    && cp /opt/nginx/modules/ngx_http_accounting_module.so \
+          /opt/nginx/modules/ngx_http_accounting_module-with-stream.so
+
+FROM alpine:3.20 AS rt
+RUN apk add --no-cache pcre zlib
+COPY --from=compile /opt/nginx /opt/nginx
+STOPSIGNAL SIGTERM

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -1,0 +1,107 @@
+# lib.sh - shared test functions
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# Colors
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+pass() { PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
+fail() { FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
+skip() { SKIP=$((SKIP+1)); echo -e "  ${YELLOW}SKIP${NC} $1"; }
+
+build_images() {
+    echo "=== Building test image ==="
+    docker build -f test/Dockerfile.test -t acc-test:rt .
+}
+
+
+image_for() {
+    echo "${IMAGE[$1]}"
+}
+
+has_module() {
+    local mode=$1 mod=$2
+    [[ " ${MODS[$mode]} " == *" $mod "* ]]
+}
+
+render_conf() {
+    local mode=$1 http_block=$2 stream_block=$3 out=$4
+    {
+        echo "${LOAD[$mode]}"
+        echo "worker_processes 1;"
+        echo "error_log /dev/stderr;"
+        echo "pid /tmp/nginx.pid;"
+        echo "events { worker_connections 64; }"
+        if [[ "$http_block" ]]; then
+            echo "http {"
+            echo "  access_log off;"
+            echo "  default_type application/octet-stream;"
+            echo "  $http_block"
+            echo "}"
+        fi
+        if [[ "$stream_block" ]]; then
+            echo "stream {"
+            echo "  $stream_block"
+            echo "}"
+        fi
+    } > "$out"
+}
+
+assert_config_ok() {
+    local mode=$1 conf=$2
+    local img=$(image_for "$mode")
+    if docker run --rm -v "$conf:/opt/nginx/conf/nginx.conf:ro" \
+        "$img" /opt/nginx/sbin/nginx -t -c /opt/nginx/conf/nginx.conf 2>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+assert_config_fail() {
+    local mode=$1 conf=$2
+    local img=$(image_for "$mode")
+    if ! docker run --rm -v "$conf:/opt/nginx/conf/nginx.conf:ro" \
+        "$img" /opt/nginx/sbin/nginx -t -c /opt/nginx/conf/nginx.conf 2>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+start_container() {
+    local mode=$1 conf=$2 ports=$3
+    local img=$(image_for "$mode")
+    local cid
+    cid=$(docker run -d $ports \
+        -v "$conf:/opt/nginx/conf/nginx.conf:ro" \
+        "$img" /opt/nginx/sbin/nginx -g "daemon off;" -c /opt/nginx/conf/nginx.conf)
+    echo "$cid"
+}
+
+stop_container() {
+    local cid=$1
+    docker kill "$cid" >/dev/null 2>&1 || true
+    docker rm "$cid" >/dev/null 2>&1 || true
+}
+
+assert_log_contains() {
+    local cid=$1 pattern=$2
+    docker logs "$cid" 2>&1 | grep -q "$pattern"
+}
+
+assert_log_not_contains() {
+    local cid=$1 pattern=$2
+    ! docker logs "$cid" 2>&1 | grep -q "$pattern"
+}
+
+print_summary() {
+    echo ""
+    echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+    return $FAIL
+}

--- a/test/matrix.sh
+++ b/test/matrix.sh
@@ -1,0 +1,30 @@
+# Matrix definitions for module modes M1-M4
+#
+# Each mode defines:
+#   IMAGE  - Docker runtime image tag (from Dockerfile.test)
+#   MODS   - space-separated list of available modules (http/stream)
+#   LOAD   - load_module directive(s) for nginx.conf
+#   DESC   - human-readable description
+
+declare -A IMAGE MODS LOAD DESC
+
+IMAGE[m1]=acc-test:rt
+MODS[m1]=http
+LOAD[m1]="load_module modules/ngx_http_accounting_module.so;"
+DESC[m1]="HTTP only (http-only build)"
+
+IMAGE[m2]=acc-test:rt
+MODS[m2]=stream
+LOAD[m2]="load_module modules/ngx_stream_accounting_module.so;"
+DESC[m2]="Stream only (stream-only build)"
+
+IMAGE[m3]=acc-test:rt
+MODS[m3]="http stream"
+LOAD[m3]="load_module modules/ngx_http_accounting_module.so;
+load_module modules/ngx_stream_accounting_module.so;"
+DESC[m3]="HTTP + Stream separate (both build)"
+
+IMAGE[m4]=acc-test:rt
+MODS[m4]=http
+LOAD[m4]="load_module modules/ngx_http_accounting_module-with-stream.so;"
+DESC[m4]="HTTP with-stream (both build, combined .so)"

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# run.sh - Test suite entry point for traffic-accounting-nginx-module
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_DIR"
+
+# Source matrix and lib
+source "$SCRIPT_DIR/matrix.sh"
+source "$SCRIPT_DIR/lib.sh"
+
+# Parse args
+FILTER_MODE=""
+FILTER_TEST=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --mode) FILTER_MODE="$2"; shift 2 ;;
+        --test) FILTER_TEST="$2"; shift 2 ;;
+        --skip-build) SKIP_BUILD=1; shift ;;
+        *) echo "Usage: $0 [--mode m1,m2] [--test v01,r01] [--skip-build]"; exit 1 ;;
+    esac
+done
+
+# Build images if needed
+if [[ "$SKIP_BUILD" != "1" ]]; then
+    build_images
+fi
+
+# Determine which modes to run
+MODES=""
+if [[ "$FILTER_MODE" ]]; then
+    for m in ${FILTER_MODE//,/ }; do MODES="$MODES $m"; done
+else
+    MODES="m1 m2 m3 m4"
+fi
+
+# Determine which tests to run
+TESTS=""
+if [[ "$FILTER_TEST" ]]; then
+    for t in ${FILTER_TEST//,/ }; do TESTS="$TESTS $t"; done
+else
+    TESTS="v01 v02 v03 v04 v05 r01 r02 r03 e01"
+fi
+
+for mode in $MODES; do
+    if [[ ! "${IMAGE[$mode]}" ]]; then
+        echo "Unknown mode: $mode"
+        exit 1
+    fi
+
+    echo ""
+    echo "=============================================="
+    echo " Mode: $mode - ${DESC[$mode]}"
+    echo "=============================================="
+
+    for tc in $TESTS; do
+        tc_file="$SCRIPT_DIR/tests/${tc}.sh"
+        if [[ -f "$tc_file" ]]; then
+            source "$tc_file"
+            "test_${tc}" "$mode"
+        fi
+    done
+done
+
+echo ""
+echo "=============================================="
+print_summary
+exit $?

--- a/test/tests/e01.sh
+++ b/test/tests/e01.sh
@@ -1,3 +1,4 @@
+# E01: error — duplicate load_module rejected
 test_e01() {
     local mode=$1
 

--- a/test/tests/e01.sh
+++ b/test/tests/e01.sh
@@ -1,0 +1,26 @@
+test_e01() {
+    local mode=$1
+
+    if ! has_module "$mode" http; then
+        skip "E01 $mode: no http module"
+        return
+    fi
+
+    # Duplicate load_module of the same .so should fail
+    local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+    {
+        echo "${LOAD[$mode]}"
+        echo "${LOAD[$mode]}"
+        echo "worker_processes 1;"
+        echo "error_log /dev/stderr;"
+        echo "events { worker_connections 64; }"
+        echo "http { access_log off; default_type application/octet-stream; accounting on; }"
+    } > "$conf"
+
+    if assert_config_fail "$mode" "$conf"; then
+        pass "E01 $mode: duplicate load_module rejected"
+    else
+        fail "E01 $mode: duplicate load_module should be rejected"
+    fi
+    rm -f "$conf"
+}

--- a/test/tests/r01.sh
+++ b/test/tests/r01.sh
@@ -1,0 +1,42 @@
+test_r01() {
+    local mode=$1
+
+    if ! has_module "$mode" http; then
+        skip "R01 $mode: no http module"
+        return
+    fi
+
+    # m3 loads two separate .so files that share global state → worker segfaults
+    if [[ "$mode" == "m3" ]]; then
+        skip "R01 $mode: separate .so conflict (SIGSEGV)"
+        return
+    fi
+
+    local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+    render_conf "$mode" \
+        "accounting on;
+         accounting_interval 2;
+         accounting_perturb off;
+         accounting_log /dev/stderr;
+         server {
+             listen 8080;
+             location / { return 200 'ok'; }
+         }" \
+        "" "$conf"
+
+    local cid
+    cid=$(start_container "$mode" "$conf" "-p 8080:8080")
+    sleep 1
+
+    timeout 5 curl -s -o /dev/null http://localhost:8080/ || true
+    sleep 3
+
+    if assert_log_contains "$cid" "accounting_id:"; then
+        pass "R01 $mode: HTTP request produces accounting log"
+    else
+        fail "R01 $mode: HTTP request should produce accounting log"
+    fi
+
+    stop_container "$cid"
+    rm -f "$conf"
+}

--- a/test/tests/r01.sh
+++ b/test/tests/r01.sh
@@ -1,3 +1,4 @@
+# R01: runtime — HTTP request triggers accounting log
 test_r01() {
     local mode=$1
 

--- a/test/tests/r02.sh
+++ b/test/tests/r02.sh
@@ -1,3 +1,4 @@
+# R02: runtime — Stream session triggers accounting log
 test_r02() {
     local mode=$1
 

--- a/test/tests/r02.sh
+++ b/test/tests/r02.sh
@@ -1,0 +1,42 @@
+test_r02() {
+    local mode=$1
+
+    if ! has_module "$mode" stream; then
+        skip "R02 $mode: no stream module"
+        return
+    fi
+
+    # m3 loads two separate .so files that share global state → worker segfaults
+    if [[ "$mode" == "m3" ]]; then
+        skip "R02 $mode: separate .so conflict (SIGSEGV)"
+        return
+    fi
+
+    local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+    render_conf "$mode" "" \
+        "accounting on;
+         accounting_interval 2;
+         accounting_perturb off;
+         accounting_log /dev/stderr;
+         server {
+             listen 9999;
+             return hello;
+         }" \
+        "$conf"
+
+    local cid
+    cid=$(start_container "$mode" "$conf" "-p 9999:9999")
+    sleep 1
+
+    timeout 5 nc -w1 localhost 9999 || true
+    sleep 3
+
+    if assert_log_contains "$cid" "accounting_id:"; then
+        pass "R02 $mode: Stream session produces accounting log"
+    else
+        fail "R02 $mode: Stream session should produce accounting log"
+    fi
+
+    stop_container "$cid"
+    rm -f "$conf"
+}

--- a/test/tests/r03.sh
+++ b/test/tests/r03.sh
@@ -1,0 +1,58 @@
+test_r03() {
+    local mode=$1
+
+    if ! has_module "$mode" http || ! has_module "$mode" stream; then
+        skip "R03 $mode: need both http and stream modules"
+        return
+    fi
+
+    # m3 loads two separate .so files that share global state → worker segfaults
+    if [[ "$mode" == "m3" ]]; then
+        skip "R03 $mode: separate .so conflict (SIGSEGV)"
+        return
+    fi
+
+    local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+    render_conf "$mode" \
+        "accounting on;
+         accounting_interval 2;
+         accounting_perturb off;
+         accounting_log /dev/stderr;
+         server {
+             listen 8080;
+             location / { return 200 'ok'; }
+         }" \
+        "accounting on;
+         accounting_interval 2;
+         accounting_perturb off;
+         accounting_log /dev/stderr;
+         server {
+             listen 9999;
+             return hello;
+         }" \
+        "$conf"
+
+    local cid
+    cid=$(start_container "$mode" "$conf" "-p 8080:8080 -p 9999:9999")
+    sleep 1
+
+    timeout 5 curl -s -o /dev/null http://localhost:8080/ || true
+    timeout 5 nc -w1 localhost 9999 || true
+    sleep 3
+
+    local logs
+    logs=$(docker logs "$cid" 2>&1)
+
+    if echo "$logs" | grep -q "accounting_id:"; then
+        if echo "$logs" | grep "accounting" | grep -q "requests"; then
+            pass "R03 $mode: Both modules produce accounting logs"
+        else
+            fail "R03 $mode: accounting logs should contain request counts"
+        fi
+    else
+        fail "R03 $mode: should produce accounting logs from both modules"
+    fi
+
+    stop_container "$cid"
+    rm -f "$conf"
+}

--- a/test/tests/r03.sh
+++ b/test/tests/r03.sh
@@ -1,3 +1,4 @@
+# R03: runtime — HTTP + Stream together produce accounting logs
 test_r03() {
     local mode=$1
 

--- a/test/tests/v01.sh
+++ b/test/tests/v01.sh
@@ -1,3 +1,4 @@
+# V01: validate accounting on in http {}
 test_v01() {
     local mode=$1
 

--- a/test/tests/v01.sh
+++ b/test/tests/v01.sh
@@ -1,0 +1,17 @@
+test_v01() {
+    local mode=$1
+
+    # accounting on in http {} main conf
+    if has_module "$mode" http; then
+        local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+        render_conf "$mode" "accounting on;" "" "$conf"
+        if assert_config_ok "$mode" "$conf"; then
+            pass "V01 $mode: accounting on in http {} passes"
+        else
+            fail "V01 $mode: accounting on in http {} should pass"
+        fi
+        rm -f "$conf"
+    else
+        skip "V01 $mode: no http module"
+    fi
+}

--- a/test/tests/v02.sh
+++ b/test/tests/v02.sh
@@ -1,3 +1,4 @@
+# V02: validate accounting on in stream {}
 test_v02() {
     local mode=$1
 

--- a/test/tests/v02.sh
+++ b/test/tests/v02.sh
@@ -1,0 +1,17 @@
+test_v02() {
+    local mode=$1
+
+    # accounting on in stream {} main conf
+    if has_module "$mode" stream; then
+        local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+        render_conf "$mode" "" "accounting on;" "$conf"
+        if assert_config_ok "$mode" "$conf"; then
+            pass "V02 $mode: accounting on in stream {} passes"
+        else
+            fail "V02 $mode: accounting on in stream {} should pass"
+        fi
+        rm -f "$conf"
+    else
+        skip "V02 $mode: no stream module"
+    fi
+}

--- a/test/tests/v03.sh
+++ b/test/tests/v03.sh
@@ -1,3 +1,4 @@
+# V03a: valid accounting_interval 30 accepted; V03b: invalid accounting_interval abc rejected
 test_v03() {
     local mode=$1
 

--- a/test/tests/v03.sh
+++ b/test/tests/v03.sh
@@ -1,0 +1,29 @@
+test_v03() {
+    local mode=$1
+
+    if has_module "$mode" http; then
+        local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+        render_conf "$mode" "accounting_interval 30;" "" "$conf"
+        if assert_config_ok "$mode" "$conf"; then
+            pass "V03a $mode: accounting_interval 30 passes"
+        else
+            fail "V03a $mode: accounting_interval 30 should pass"
+        fi
+        rm -f "$conf"
+    else
+        skip "V03a $mode: no http module"
+    fi
+
+    if has_module "$mode" http; then
+        local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+        render_conf "$mode" "accounting_interval abc;" "" "$conf"
+        if assert_config_fail "$mode" "$conf"; then
+            pass "V03b $mode: accounting_interval abc rejected"
+        else
+            fail "V03b $mode: accounting_interval abc should be rejected"
+        fi
+        rm -f "$conf"
+    else
+        skip "V03b $mode: no http module"
+    fi
+}

--- a/test/tests/v04.sh
+++ b/test/tests/v04.sh
@@ -1,0 +1,17 @@
+test_v04() {
+    local mode=$1
+
+    if ! has_module "$mode" http; then
+        skip "V04 $mode: no http module"
+        return
+    fi
+
+    local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+    render_conf "$mode" "accounting_log /dev/stderr;" "" "$conf"
+    if assert_config_ok "$mode" "$conf"; then
+        pass "V04 $mode: accounting_log /dev/stderr passes"
+    else
+        fail "V04 $mode: accounting_log /dev/stderr should pass"
+    fi
+    rm -f "$conf"
+}

--- a/test/tests/v04.sh
+++ b/test/tests/v04.sh
@@ -1,3 +1,4 @@
+# V04: validate accounting_log /dev/stderr
 test_v04() {
     local mode=$1
 

--- a/test/tests/v05.sh
+++ b/test/tests/v05.sh
@@ -1,0 +1,33 @@
+test_v05() {
+    local mode=$1
+
+    if has_module "$mode" http; then
+        local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+        render_conf "$mode" \
+            "accounting_id 'GLOBAL'; server { listen 8080; location / { return 200; accounting_id 'LOCAL'; } }" \
+            "" "$conf"
+        if assert_config_ok "$mode" "$conf"; then
+            pass "V05a $mode: accounting_id at server+location passes"
+        else
+            fail "V05a $mode: accounting_id at server+location should pass"
+        fi
+        rm -f "$conf"
+    else
+        skip "V05a $mode: no http module"
+    fi
+
+    if has_module "$mode" stream; then
+        local conf=$(mktemp /tmp/acc-XXXXXX.conf)
+        render_conf "$mode" "" \
+            "accounting_id 'STREAMID'; server { listen 9999; return hello; }" \
+            "$conf"
+        if assert_config_ok "$mode" "$conf"; then
+            pass "V05b $mode: accounting_id in stream server passes"
+        else
+            fail "V05b $mode: accounting_id in stream server should pass"
+        fi
+        rm -f "$conf"
+    else
+        skip "V05b $mode: no stream module"
+    fi
+}

--- a/test/tests/v05.sh
+++ b/test/tests/v05.sh
@@ -1,3 +1,4 @@
+# V05a: accounting_id at http server+location; V05b: accounting_id in stream server
 test_v05() {
     local mode=$1
 


### PR DESCRIPTION
### Changes

Split the monolithic nginx module config into two separate config files:

- **config** — HTTP-only build (`ngx_http_accounting_module.so`)
- **stream/config** — Stream-only build (`ngx_stream_accounting_module.so`)

The combined build (`ngx_http_accounting_module-with-stream.so`) is produced at packaging time by copying the HTTP .so artifact.

### Test suite

Verifies all 4 build modes across 9 test cases (config validation, runtime, error handling) via GHA:

| Mode | Description | Build |
|------|-------------|-------|
| m1 | HTTP only | `config` |
| m2 | Stream only | `stream/config` |
| m3 | HTTP + Stream separate | both .so files loaded |
| m4 | HTTP with-stream combined | combined .so loaded |

### Notes

- **Breaking**: users of the stream module must add `load_module modules/ngx_stream_accounting_module.so;` to their nginx.conf
- Loading both separate .so files (m3) causes worker SIGSEGV — a pre-existing source-level issue (shared globals in `src/` files). Use the combined .so (m4) or load only one module.