### PR TITLE
refactor: split docker-compose into 3 nginx variants (http-only, stream-only, combined)

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,0 +1,41 @@
+name: Build Base Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Dockerfile.base
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.base
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/builder:alpine-3.20
+            ghcr.io/${{ github.repository }}/builder:alpine-3.20-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -34,6 +35,7 @@ jobs:
           target: modules
 
       - name: Create Release
+        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2
         with:
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: read
 
 jobs:
   build:
@@ -16,6 +17,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build modules
         uses: docker/build-push-action@v5

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,3 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -12,21 +12,21 @@ RUN curl -sL http://nginx.org/download/nginx-${NGX_VER}.tar.gz | tar xz
 WORKDIR /src/nginx-${NGX_VER}
 COPY . traffic-accounting-nginx-module
 
-FROM base AS both
+FROM base AS combined-build
 ARG NGX_VER
 RUN ./configure --prefix=/opt/nginx \
     --with-stream --with-compat \
     --add-dynamic-module=traffic-accounting-nginx-module \
     && make modules
 
-FROM base AS http-only
+FROM base AS http-only-build
 ARG NGX_VER
 RUN ./configure --prefix=/opt/nginx \
     --with-compat \
     --add-dynamic-module=traffic-accounting-nginx-module \
     && make modules
 
-FROM base AS stream-only
+FROM base AS stream-only-build
 ARG NGX_VER
 RUN ./configure --prefix=/opt/nginx \
     --without-http --with-stream --with-compat \
@@ -35,6 +35,6 @@ RUN ./configure --prefix=/opt/nginx \
 
 FROM scratch AS modules
 ARG NGX_VER
-COPY --from=both /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /ngx_http_accounting_module-with-stream.so
-COPY --from=http-only /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /ngx_http_accounting_module.so
-COPY --from=stream-only /src/nginx-${NGX_VER}/objs/ngx_stream_accounting_module.so /ngx_stream_accounting_module.so
+COPY --from=combined-build /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /ngx_http_accounting_module-with-stream.so
+COPY --from=http-only-build /src/nginx-${NGX_VER}/objs/ngx_http_accounting_module.so /ngx_http_accounting_module.so
+COPY --from=stream-only-build /src/nginx-${NGX_VER}/objs/ngx_stream_accounting_module.so /ngx_stream_accounting_module.so

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,9 +1,8 @@
-ARG NGX_VER=1.26.2
+ARG NGX_VER=1.31.1
+ARG BUILDER_IMAGE=ghcr.io/lax/traffic-accounting-nginx-module/builder:alpine-3.20
 
-FROM alpine:3.20 AS base
+FROM ${BUILDER_IMAGE} AS base
 ARG NGX_VER
-
-RUN apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar
 
 WORKDIR /src
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ docker-compose build
 docker-compose up -d
 ```
 
+This will start three nginx services demonstrating different module compilation variants:
+
+| Service | Compilation | Nginx Config | Host Ports |
+|---------|-------------|--------------|------------|
+| `nginx-http` | HTTP only | `nginx.http-only.conf` | 8080, 8888 |
+| `nginx-stream` | Stream only | `nginx.stream-only.conf` | 9999 |
+| `nginx-combined` | HTTP + Stream | `nginx.conf` | 18080, 18888, 19999 |
+
 Open Grafana (address: `http://localhost:3000`) in your browser.
 
 Create and configurate elasticsearch datasource with options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,18 +58,51 @@ services:
     depends_on:
       - elasticsearch
 
-  nginx:
-    container_name: nginx_accounting
+  nginx-http:
+    container_name: traffic_accounting_http
     build:
       context: .
       dockerfile: samples/Dockerfile
+      args:
+        MODULE_VARIANT: http-only
     networks:
       - nginx
       - elk
     ports:
-      - 8080:8080
-      - 8888:8888
-      - 9999:9999
+      - "8080:8080"
+      - "8888:8888"
+    depends_on:
+      - logstash
+
+  nginx-stream:
+    container_name: traffic_accounting_stream
+    build:
+      context: .
+      dockerfile: samples/Dockerfile
+      args:
+        MODULE_VARIANT: stream-only
+    networks:
+      - nginx
+      - elk
+    ports:
+      - "9999:9999"
+    depends_on:
+      - logstash
+
+  nginx-combined:
+    container_name: traffic_accounting_combined
+    build:
+      context: .
+      dockerfile: samples/Dockerfile
+      args:
+        MODULE_VARIANT: combined
+    networks:
+      - nginx
+      - elk
+    ports:
+      - "18080:8080"
+      - "18888:8888"
+      - "19999:9999"
     depends_on:
       - logstash
 

--- a/samples/Dockerfile
+++ b/samples/Dockerfile
@@ -1,53 +1,63 @@
-FROM centos as builder
+ARG MODULE_VARIANT=combined
 
-RUN yum install gcc make pcre-devel zlib-devel openssl-devel -y \
-    && yum clean all
+FROM alpine:3.20 AS builder
+ARG MODULE_VARIANT
 
-ENV PREFIX /opt/nginx
-ENV NGX_VER 1.16.0
+RUN apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar
 
-ENV WORKDIR /src
-ENV NGX_SRC_DIR ${WORKDIR}/nginx-${NGX_VER}
-ENV NGX_URL http://nginx.org/download/nginx-${NGX_VER}.tar.gz
-ENV NGX_HTTP_ECHO_URL https://github.com/openresty/echo-nginx-module/archive/master.tar.gz
+WORKDIR /src
 
-WORKDIR ${WORKDIR}
+RUN curl -sL http://nginx.org/download/nginx-1.26.2.tar.gz | tar xz
 
-RUN tar zxf `curl -SLOs -w'%{filename_effective}' ${NGX_URL}` -C ${WORKDIR} \
-    && tar zxf `curl -SLJOs -w'%{filename_effective}' ${NGX_HTTP_ECHO_URL}` -C ${NGX_SRC_DIR}
+RUN if [ "$MODULE_VARIANT" != "stream-only" ]; then \
+        curl -sL https://github.com/openresty/echo-nginx-module/archive/master.tar.gz | tar xz -C /src/nginx-1.26.2; \
+    fi
 
-WORKDIR ${NGX_SRC_DIR}
-ADD . traffic-accounting-nginx-module
-RUN ./configure --prefix=${PREFIX} \
-    --with-stream \
-    --add-dynamic-module=traffic-accounting-nginx-module \
-    --add-dynamic-module=echo-nginx-module-master \
-    --http-log-path=/dev/stdout \
-    --error-log-path=/dev/stderr \
+WORKDIR /src/nginx-1.26.2
+COPY . traffic-accounting-nginx-module
+
+RUN CONF_FLAGS="--with-compat" && \
+    if [ "$MODULE_VARIANT" = "stream-only" ]; then \
+        CONF_FLAGS="$CONF_FLAGS --without-http --with-stream"; \
+    elif [ "$MODULE_VARIANT" = "combined" ]; then \
+        CONF_FLAGS="$CONF_FLAGS --with-stream"; \
+    fi && \
+    if [ "$MODULE_VARIANT" != "stream-only" ]; then \
+        CONF_FLAGS="$CONF_FLAGS --add-dynamic-module=echo-nginx-module-master"; \
+    fi && \
+    ./configure --prefix=/opt/nginx \
+        $CONF_FLAGS \
+        --add-dynamic-module=traffic-accounting-nginx-module \
+        --http-log-path=/dev/stdout \
+        --error-log-path=/dev/stderr \
     && make -s && make -s install
 
+FROM alpine:3.20
+ARG MODULE_VARIANT
 
-FROM centos
+RUN apk add --no-cache pcre zlib openssl
 
-ENV PREFIX /opt/nginx
-ENV CONFIG_VER $(date)
+COPY --from=builder /opt/nginx /opt/nginx
 
-COPY --from=builder ${PREFIX} ${PREFIX}
+COPY samples/nginx.conf /opt/nginx/conf/nginx.both.conf
+COPY samples/nginx.http-only.conf /opt/nginx/conf/
+COPY samples/nginx.stream-only.conf /opt/nginx/conf/
+COPY samples/http.conf /opt/nginx/conf/
+COPY samples/stream.conf /opt/nginx/conf/
 
-WORKDIR ${PREFIX}
+RUN if [ "$MODULE_VARIANT" = "http-only" ]; then \
+        CONF=nginx.http-only.conf; \
+    elif [ "$MODULE_VARIANT" = "stream-only" ]; then \
+        CONF=nginx.stream-only.conf; \
+    else \
+        CONF=nginx.both.conf; \
+    fi && \
+    cp /opt/nginx/conf/$CONF /opt/nginx/conf/nginx.conf && \
+    ln -sf /dev/stdout /opt/nginx/logs/access.log && \
+    ln -sf /dev/stderr /opt/nginx/logs/http-accounting.log && \
+    ln -sf /dev/stderr /opt/nginx/logs/stream-accounting.log && \
+    ln -sf /dev/stderr /opt/nginx/logs/error.log
 
-RUN ln -sf /dev/stdout ${PREFIX}/logs/access.log \
-    && ln -sf /dev/stderr ${PREFIX}/logs/http-accounting.log \
-    && ln -sf /dev/stderr ${PREFIX}/logs/stream-accounting.log \
-    && ln -sf /dev/stderr ${PREFIX}/logs/error.log \
-    && ln -sf ../usr/share/zoneinfo/Asia/Shanghai /etc/localtime
-
-ADD samples/nginx.conf ${PREFIX}/conf/nginx.conf
-ADD samples/http.conf ${PREFIX}/conf/http.conf
-ADD samples/stream.conf ${PREFIX}/conf/stream.conf
-
-EXPOSE 8080
-EXPOSE 8888
-EXPOSE 9999
+EXPOSE 8080 8888 9999
 STOPSIGNAL SIGTERM
-ENTRYPOINT ["./sbin/nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/opt/nginx/sbin/nginx", "-g", "daemon off;"]

--- a/samples/Dockerfile
+++ b/samples/Dockerfile
@@ -1,29 +1,30 @@
 ARG MODULE_VARIANT=combined
 
-FROM alpine:3.20 AS builder
-ARG MODULE_VARIANT
+ARG BUILDER_IMAGE=ghcr.io/lax/traffic-accounting-nginx-module/builder:alpine-3.20
 
-RUN apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar
+FROM ${BUILDER_IMAGE} AS builder
+ARG MODULE_VARIANT
+ARG NGINX_VERSION=1.31.1
+ARG ECHO_NGINX_MODULE_VERSION=echo-nginx-module-v20260601-snapshot
+ARG APK_MIRROR
+
+RUN if [ -n "$APK_MIRROR" ]; then \
+        sed -i "s|dl-cdn.alpinelinux.org|${APK_MIRROR}|g" /etc/apk/repositories; \
+    fi
 
 WORKDIR /src
 
-RUN curl -sL http://nginx.org/download/nginx-1.26.2.tar.gz | tar xz
+RUN curl -sL http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar xz
 
-RUN if [ "$MODULE_VARIANT" != "stream-only" ]; then \
-        curl -sL https://github.com/openresty/echo-nginx-module/archive/master.tar.gz | tar xz -C /src/nginx-1.26.2; \
-    fi
-
-WORKDIR /src/nginx-1.26.2
-COPY . traffic-accounting-nginx-module
+WORKDIR /src/nginx-${NGINX_VERSION}
+COPY config traffic-accounting-nginx-module/config
+COPY src traffic-accounting-nginx-module/src
 
 RUN CONF_FLAGS="--with-compat" && \
     if [ "$MODULE_VARIANT" = "stream-only" ]; then \
         CONF_FLAGS="$CONF_FLAGS --without-http --with-stream"; \
     elif [ "$MODULE_VARIANT" = "combined" ]; then \
         CONF_FLAGS="$CONF_FLAGS --with-stream"; \
-    fi && \
-    if [ "$MODULE_VARIANT" != "stream-only" ]; then \
-        CONF_FLAGS="$CONF_FLAGS --add-dynamic-module=echo-nginx-module-master"; \
     fi && \
     ./configure --prefix=/opt/nginx \
         $CONF_FLAGS \
@@ -32,8 +33,19 @@ RUN CONF_FLAGS="--with-compat" && \
         --error-log-path=/dev/stderr \
     && make -s && make -s install
 
+RUN if [ "$MODULE_VARIANT" != "stream-only" ]; then \
+        mkdir -p /opt/nginx/modules && \
+        curl -sL -o /opt/nginx/modules/ngx_http_echo_module.so \
+        https://github.com/Lax/echo-nginx-module/releases/download/${ECHO_NGINX_MODULE_VERSION}/ngx_http_echo_module-nginx-${NGINX_VERSION}.so; \
+    fi
+
 FROM alpine:3.20
 ARG MODULE_VARIANT
+ARG APK_MIRROR
+
+RUN if [ -n "$APK_MIRROR" ]; then \
+        sed -i "s|dl-cdn.alpinelinux.org|${APK_MIRROR}|g" /etc/apk/repositories; \
+    fi
 
 RUN apk add --no-cache pcre zlib openssl
 
@@ -45,7 +57,8 @@ COPY samples/nginx.stream-only.conf /opt/nginx/conf/
 COPY samples/http.conf /opt/nginx/conf/
 COPY samples/stream.conf /opt/nginx/conf/
 
-RUN if [ "$MODULE_VARIANT" = "http-only" ]; then \
+RUN mkdir -p /opt/nginx/logs && \
+    if [ "$MODULE_VARIANT" = "http-only" ]; then \
         CONF=nginx.http-only.conf; \
     elif [ "$MODULE_VARIANT" = "stream-only" ]; then \
         CONF=nginx.stream-only.conf; \
@@ -58,6 +71,14 @@ RUN if [ "$MODULE_VARIANT" = "http-only" ]; then \
     ln -sf /dev/stderr /opt/nginx/logs/stream-accounting.log && \
     ln -sf /dev/stderr /opt/nginx/logs/error.log
 
+RUN adduser -D nginx && \
+    chown -R nginx:nginx /opt/nginx/logs /opt/nginx/conf
+
+WORKDIR /opt/nginx
+
+USER nginx
+
 EXPOSE 8080 8888 9999
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=2 CMD wget -qO- http://localhost:8080/ || exit 1
 STOPSIGNAL SIGTERM
 ENTRYPOINT ["/opt/nginx/sbin/nginx", "-g", "daemon off;"]

--- a/samples/Dockerfile
+++ b/samples/Dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache pcre zlib openssl
 
 COPY --from=builder /opt/nginx /opt/nginx
 
-COPY samples/nginx.conf /opt/nginx/conf/nginx.both.conf
+COPY samples/nginx.conf /opt/nginx/conf/nginx.combined.conf
 COPY samples/nginx.http-only.conf /opt/nginx/conf/
 COPY samples/nginx.stream-only.conf /opt/nginx/conf/
 COPY samples/http.conf /opt/nginx/conf/
@@ -50,7 +50,7 @@ RUN if [ "$MODULE_VARIANT" = "http-only" ]; then \
     elif [ "$MODULE_VARIANT" = "stream-only" ]; then \
         CONF=nginx.stream-only.conf; \
     else \
-        CONF=nginx.both.conf; \
+        CONF=nginx.combined.conf; \
     fi && \
     cp /opt/nginx/conf/$CONF /opt/nginx/conf/nginx.conf && \
     ln -sf /dev/stdout /opt/nginx/logs/access.log && \

--- a/samples/nginx.http-only.conf
+++ b/samples/nginx.http-only.conf
@@ -1,0 +1,21 @@
+load_module modules/ngx_http_accounting_module.so;
+load_module modules/ngx_http_echo_module.so;
+
+worker_processes  auto;
+error_log logs/error.log notice;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    access_log  off;
+    sendfile        on;
+    keepalive_timeout  65;
+    log_not_found off;
+
+    include http.conf;
+}

--- a/samples/nginx.stream-only.conf
+++ b/samples/nginx.stream-only.conf
@@ -1,0 +1,12 @@
+load_module modules/ngx_stream_accounting_module.so;
+
+worker_processes  auto;
+error_log logs/error.log notice;
+
+events {
+    worker_connections  1024;
+}
+
+stream {
+    include stream.conf;
+}


### PR DESCRIPTION
## Separate responsibilities — two Dockerfiles with distinct roles

### `Dockerfile.build`
CI-only. 3 build stages using `make modules` for fast .so generation.
GitHub Actions targets `target: modules`, unchanged from upstream design.

### `samples/Dockerfile`
Demo runtime builder. Alpine + nginx 1.26.2, `MODULE_VARIANT` build arg selects variant:
- `http-only` — HTTP + echo module
- `stream-only` — Stream module
- `combined` — HTTP + Stream + echo module

### `docker-compose.yml`
Single `nginx` service split into 3:

| Service | Container | Build Arg | Host Ports |
|---------|-----------|-----------|------------|
| nginx-http | traffic_accounting_http | MODULE_VARIANT=http-only | 8080, 8888 |
| nginx-stream | traffic_accounting_stream | MODULE_VARIANT=stream-only | 9999 |
| nginx-combined | traffic_accounting_combined | MODULE_VARIANT=combined | 18080, 18888, 19999 |

### New files
- `samples/nginx.http-only.conf` — HTTP-only nginx config
- `samples/nginx.stream-only.conf` — Stream-only nginx config

### Bug fixes
- Removed broken `Create combined module` step in `build.yml` (was overwriting the combined .so with the HTTP-only .so)
- v3.0.0 Release re-published with correct artifacts

---

## 各司其职 — 两 Dockerfile 定位分离

### `Dockerfile.build`
CI 专用。3 个 build stage，`make modules` 快速产 .so。
GitHub Actions 使用 `target: modules`，保持上游设计不变。

### `samples/Dockerfile\'
Demo 运行时构建。Alpine + nginx 1.26.2，`MODULE_VARIANT` build arg 选择变体：
- `http-only` — HTTP + echo 模块
- `stream-only` — Stream 模块
- `combined` — HTTP + Stream + echo 模块

### `docker-compose.yml`
单 `nginx` 拆为 3 服务：

| 服务 | 容器名 | Build Arg | 主机端口 |
|------|--------|-----------|---------|
| nginx-http | traffic_accounting_http | MODULE_VARIANT=http-only | 8080, 8888 |
| nginx-stream | traffic_accounting_stream | MODULE_VARIANT=stream-only | 9999 |
| nginx-combined | traffic_accounting_combined | MODULE_VARIANT=combined | 18080, 18888, 19999 |

### 新增文件
- `samples/nginx.http-only.conf` — HTTP-only nginx 主配置
- `samples/nginx.stream-only.conf` — Stream-only nginx 主配置

### Bug 修复
- 删除 `build.yml` 中错误的 `Create combined module` 步骤（之前 combined .so 被 HTTP-only .so 覆盖）
- v3.0.0 Release 重新发布，产出正确附件