### PR TITLE
test: combined module cross-nginx compatibility verification

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,61 @@
+ARG NGX_VER=1.31.1
+
+FROM alpine:3.20 AS base
+ARG NGX_VER
+RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.aliyun.com|g' /etc/apk/repositories \
+ && apk add --no-cache build-base pcre-dev zlib-dev openssl-dev linux-headers curl tar
+WORKDIR /src
+RUN curl -sL http://nginx.org/download/nginx-${NGX_VER}.tar.gz | tar xz
+WORKDIR /src/nginx-${NGX_VER}
+COPY . traffic-accounting-nginx-module
+
+FROM base AS build-combined
+RUN ./configure --prefix=/opt/nginx --with-compat --with-stream \
+    --add-dynamic-module=traffic-accounting-nginx-module \
+    && make -j$(nproc) install
+
+FROM base AS build-http-only
+RUN ./configure --prefix=/opt/nginx --with-compat \
+    && make -j$(nproc) install
+
+FROM base AS build-stream-only
+RUN ./configure --prefix=/opt/nginx --with-compat --without-http --with-stream \
+    && make -j$(nproc) install
+
+# ---- test-http-stream: nginx(http+stream) + combined module ----
+FROM alpine:3.20 AS test-http-stream
+ARG NGX_VER
+RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.aliyun.com|g' /etc/apk/repositories \
+ && apk add --no-cache pcre-dev zlib-dev openssl-dev libgcc libstdc++
+COPY --from=build-combined /opt/nginx/ /opt/nginx/
+COPY conf/http-stream.conf /opt/nginx/conf/nginx.conf
+RUN ln -sf /dev/stdout /opt/nginx/logs/access.log \
+    && ln -sf /dev/stderr /opt/nginx/logs/error.log
+EXPOSE 8080 9090
+CMD ["/opt/nginx/sbin/nginx", "-g", "daemon off;"]
+
+# ---- test-http-only: nginx(http-only) + combined module ----
+FROM alpine:3.20 AS test-http-only
+ARG NGX_VER
+RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.aliyun.com|g' /etc/apk/repositories \
+ && apk add --no-cache pcre-dev zlib-dev openssl-dev libgcc libstdc++
+COPY --from=build-http-only /opt/nginx/ /opt/nginx/
+COPY --from=build-combined /opt/nginx/modules/ngx_http_accounting_module.so /opt/nginx/modules/
+COPY conf/http-only.conf /opt/nginx/conf/nginx.conf
+RUN ln -sf /dev/stdout /opt/nginx/logs/access.log \
+    && ln -sf /dev/stderr /opt/nginx/logs/error.log
+EXPOSE 8080
+CMD ["/opt/nginx/sbin/nginx", "-g", "daemon off;"]
+
+# ---- test-stream-only: nginx(stream-only) + combined module ----
+FROM alpine:3.20 AS test-stream-only
+ARG NGX_VER
+RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.aliyun.com|g' /etc/apk/repositories \
+ && apk add --no-cache pcre-dev zlib-dev openssl-dev libgcc libstdc++
+COPY --from=build-stream-only /opt/nginx/ /opt/nginx/
+COPY --from=build-combined /opt/nginx/modules/ngx_http_accounting_module.so /opt/nginx/modules/
+COPY conf/stream-only.conf /opt/nginx/conf/nginx.conf
+RUN ln -sf /dev/stdout /opt/nginx/logs/access.log \
+    && ln -sf /dev/stderr /opt/nginx/logs/error.log
+EXPOSE 9090
+CMD ["/opt/nginx/sbin/nginx", "-g", "daemon off;"]

--- a/TEST_REPORT.md
+++ b/TEST_REPORT.md
@@ -1,0 +1,59 @@
+# Test Report: combined module cross-nginx compatibility
+
+## Goal
+
+Test whether the **combined** module (`ngx_http_accounting_module.so`, containing both HTTP and Stream modules) can be loaded on 3 nginx variants:
+
+- http+stream nginx
+- http-only nginx (no `--with-stream`)
+- stream-only nginx (`--without-http`)
+
+If the combined module works universally, the http-only/stream-only build options could be removed.
+
+## Test Setup
+
+3 containers via `Dockerfile.test`, each running a different nginx binary but all using the **same** combined `.so` built with `--with-compat --with-stream`.
+
+| Container | Nginx build flags | Config | Expected |
+|---|---|---|---|
+| ta-test-http-stream | `--with-compat --with-stream` | `http{}` + `stream{}` | ✅ start |
+| ta-test-http-only | `--with-compat` (no stream) | `http{}` only | ❌ dlopen fail |
+| ta-test-stream-only | `--with-compat --without-http --with-stream` | `stream{}` only | ❌ dlopen fail |
+
+## Results
+
+All 3 tests passed as expected:
+
+### 1. http+stream + combined ✅
+```
+[notice] start worker process 7
+[notice] pid:7|start http traffic accounting
+[notice] pid:7|start stream traffic accounting
+```
+→ Both HTTP and Stream accounting modules loaded successfully.
+
+### 2. http-only + combined ❌
+```
+[emerg] dlopen() "...ngx_http_accounting_module.so" failed
+  (Error relocating ... : ngx_stream_get_indexed_variable: symbol not found)
+```
+→ HTTP-only nginx lacks the Stream subsystem symbols.
+
+### 3. stream-only + combined ❌
+```
+[emerg] dlopen() "...ngx_http_accounting_module.so" failed
+  (Error relocating ... : ngx_http_get_indexed_variable: symbol not found)
+```
+→ Stream-only nginx lacks the HTTP subsystem symbols.
+
+## Root Cause
+
+The combined `.so` references symbols from both subsystems:
+- `ngx_stream_get_indexed_variable` (from `src/stream/ngx_stream_accounting_module.c:290`)
+- `ngx_http_get_indexed_variable` (from `src/http/ngx_http_accounting_module.c:300`)
+
+Nginx uses `dlopen(RTLD_NOW)`, so any unresolved symbol causes immediate load failure.
+
+## Conclusion
+
+**http-only and stream-only build options cannot be removed.** The combined module only works on http+stream nginx. Users with single-protocol nginx builds must use the corresponding single-protocol module variant.

--- a/conf/http-only.conf
+++ b/conf/http-only.conf
@@ -1,0 +1,17 @@
+load_module modules/ngx_http_accounting_module.so;
+worker_processes 1;
+error_log /dev/stderr notice;
+pid /tmp/nginx.pid;
+events { worker_connections 1024; }
+
+http {
+    access_log off;
+    accounting on;
+    accounting_interval 99999;
+    accounting_id '$host';
+    accounting_log /dev/stdout;
+    server {
+        listen 8080;
+        location / { return 200 'ok\n'; accounting_id '/'; }
+    }
+}

--- a/conf/http-stream.conf
+++ b/conf/http-stream.conf
@@ -1,0 +1,25 @@
+load_module modules/ngx_http_accounting_module.so;
+worker_processes 1;
+error_log /dev/stderr notice;
+pid /tmp/nginx.pid;
+events { worker_connections 1024; }
+
+http {
+    access_log off;
+    accounting on;
+    accounting_interval 99999;
+    accounting_id '$host';
+    accounting_log /dev/stdout;
+    server {
+        listen 8080;
+        location / { return 200 'ok\n'; accounting_id '/'; }
+    }
+}
+
+stream {
+    accounting on;
+    accounting_interval 99999;
+    accounting_id 'STREAM';
+    accounting_log /dev/stdout;
+    server { listen 9090; }
+}

--- a/conf/stream-only.conf
+++ b/conf/stream-only.conf
@@ -1,0 +1,13 @@
+load_module modules/ngx_http_accounting_module.so;
+worker_processes 1;
+error_log /dev/stderr notice;
+pid /tmp/nginx.pid;
+events { worker_connections 1024; }
+
+stream {
+    accounting on;
+    accounting_interval 99999;
+    accounting_id 'STREAM';
+    accounting_log /dev/stdout;
+    server { listen 9090; }
+}

--- a/test-combined.sh
+++ b/test-combined.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+echo "=== Step 1: Build all test images ==="
+docker build -f Dockerfile.test --target test-http-stream -t ta-test-http-stream .
+docker build -f Dockerfile.test --target test-http-only   -t ta-test-http-only .
+docker build -f Dockerfile.test --target test-stream-only -t ta-test-stream-only
+
+echo ""
+echo "==========================================="
+echo " Test 1: nginx(http+stream) + combined.so "
+echo "==========================================="
+docker run --rm ta-test-http-stream 2>&1 &
+pid=$!
+sleep 2
+if kill -0 $pid 2>/dev/null; then
+    echo ">>> [PASS] nginx started successfully (http+stream + combined)"
+    kill $pid 2>/dev/null; wait $pid 2>/dev/null
+else
+    wait $pid 2>/dev/null
+    echo ">>> [FAIL] nginx failed to start"
+fi
+
+echo ""
+echo "==========================================="
+echo " Test 2: nginx(http-only) + combined.so  "
+echo "==========================================="
+docker run --rm ta-test-http-only 2>&1 &
+pid=$!
+sleep 2
+if kill -0 $pid 2>/dev/null; then
+    echo ">>> [FAIL] nginx should NOT have started"
+    kill $pid 2>/dev/null; wait $pid 2>/dev/null
+else
+    wait $pid 2>/dev/null
+    echo ">>> [PASS] nginx correctly rejected combined.so on http-only build"
+fi
+
+echo ""
+echo "==========================================="
+echo " Test 3: nginx(stream-only) + combined.so"
+echo "==========================================="
+docker run --rm ta-test-stream-only 2>&1 &
+pid=$!
+sleep 2
+if kill -0 $pid 2>/dev/null; then
+    echo ">>> [FAIL] nginx should NOT have started"
+    kill $pid 2>/dev/null; wait $pid 2>/dev/null
+else
+    wait $pid 2>/dev/null
+    echo ">>> [PASS] nginx correctly rejected combined.so on stream-only build"
+fi


### PR DESCRIPTION
## Summary

验证 combined 模块（含 HTTP + Stream 两个子模块的 `.so`）在 3 种 nginx 变体上的兼容性，确定 http-only / stream-only 构建选项是否可废弃。

### 测试矩阵

| nginx 变体 | 模块 | 预期 |
|---|---|---|
| http+stream | combined | ✅ 启动成功 |
| http-only | combined | ❌ dlopen 失败 |
| stream-only | combined | ❌ dlopen 失败 |

### 结果

3 项测试均符合预期。Combined 模块引用了 `ngx_stream_get_indexed_variable` 和 `ngx_http_get_indexed_variable` 两个子系统符号，单协议 nginx 无法解析，`dlopen(RTLD_NOW)` 直接失败。

### 结论

**http-only 和 stream-only 两种构建选项必须保留。**

详见 TEST_REPORT.md、Dockerfile.test。可用于后续回归验证。